### PR TITLE
feat: custom EFI Boot Entry Names

### DIFF
--- a/modules/install.py
+++ b/modules/install.py
@@ -192,7 +192,7 @@ LABEL=home_ab /home  ext4  defaults,noatime 0 2
     run_command(f"mkdir -p {esp_a_mount_dir}")
     try:
         run_command(f"mount {part1} {esp_a_mount_dir}")
-        run_command(f"bootctl --esp-path={esp_a_mount_dir} install")
+        run_command(f"bootctl --esp-path={esp_a_mount_dir} --efi-boot-option-description=\"ObsidianOS (Slot A)\" install")
     finally:
         run_command(f"umount {esp_a_mount_dir}", check=False)
         run_command(f"rm -r {esp_a_mount_dir}", check=False)
@@ -202,7 +202,7 @@ LABEL=home_ab /home  ext4  defaults,noatime 0 2
     run_command(f"mkdir -p {esp_b_mount_dir}")
     try:
         run_command(f"mount {part2} {esp_b_mount_dir}")
-        run_command(f"bootctl --esp-path={esp_b_mount_dir} install")
+        run_command(f"bootctl --esp-path={esp_b_mount_dir} --efi-boot-option-description=\"ObsidianOS (Slot B)\" install")
     finally:
         run_command(f"umount {esp_b_mount_dir}", check=False)
         run_command(f"rm -r {esp_b_mount_dir}", check=False)


### PR DESCRIPTION
Changed EFI Boot Entry Names from two "Linux Boot Manager" to "ObsidianOS (Slot A)" and "ObsidianOS (Slot B)". please note that choosing slots from the UEFI Boot Menu will only change the bootloader slot, as for initramfs, kernel and the rootfs you gotta hold space before booting to see a menu.

Please "Squash and Merge", not just "Merge" :)